### PR TITLE
Don't close a pty that was never started as it causes a panic

### DIFF
--- a/run_windows.go
+++ b/run_windows.go
@@ -66,7 +66,6 @@ func StartWithAttrs(c *exec.Cmd, sz *Winsize, attrs *syscall.SysProcAttr) (Pty, 
 
 	err = w.Start()
 	if err != nil {
-		_ = pty.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
I'm not sure what this close was meant to achieve and whether this might cause issues if Start failed later on. But in my opinion this should be handled inside `Start()` rather than by its consuming code.

As a consumer it stands to reason that if Start failed there would be nothing to close, so this felt like a sensible solution to the problem I was facing.

Realize you aren't necessarily maintaining the windows implementation, but as it has yet to be accepted onto the main repo it felt appropriate to PR here.

Thanks so much for developing the windows solution!

Edit:

To reproduce the bug I was running simply specify an executable by name which isn't on PATH (I was using `bash`).

After this fix I now get the following error:

```could not start pty: exec: "bash": executable file not found in %PATH%```

Before it would panic (or even fail silently depending on how you ran your tests).