### PR TITLE
Don't close consoleR & consoleW in Windows

### DIFF
--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -28,12 +28,14 @@ type windowExecCmd struct {
 	cmd        *exec.Cmd
 	waitCalled bool
 	conPty     *WindowsPty
+	conTty     *WindowsTty
 	attrList   *windows.ProcThreadAttributeListContainer
 }
 
 func (c *windowExecCmd) close() error {
 	c.attrList.Delete()
 	_ = c.conPty.Close()
+	_ = c.conTty.Close()
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/creack/pty/v2
 
-go 1.18
+go 1.21.5
 
 require golang.org/x/sys v0.13.0

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"testing"
 )
 
-// openCloses opens a pty/tty pair and stages the closing as part of the cleanup.
-func openClose(t *testing.T) (pty, tty *os.File) {
+// openClose opens a pty/tty pair and stages the closing as part of the cleanup.
+func openClose(t *testing.T) (Pty, Tty) {
 	t.Helper()
 
 	pty, tty, err := Open()

--- a/pty_windows.go
+++ b/pty_windows.go
@@ -74,14 +74,6 @@ func open() (_ Pty, _ Tty, err error) {
 		return nil, nil, err
 	}
 
-	// These pipes can be closed here without any worry.
-	if err := consoleW.Close(); err != nil {
-		return nil, nil, fmt.Errorf("failed to close pseudo console write handle: %w", err)
-	}
-	if err := consoleR.Close(); err != nil {
-		return nil, nil, fmt.Errorf("failed to close pseudo console read handle: %w", err)
-	}
-
 	return &WindowsPty{
 			handle: consoleHandle,
 			r:      pr,

--- a/run_windows.go
+++ b/run_windows.go
@@ -34,7 +34,7 @@ func StartWithSize(c *exec.Cmd, sz *Winsize) (Pty, error) {
 // This should generally not be needed. Used in some edge cases where it is needed to create a pty
 // without a controlling terminal.
 func StartWithAttrs(c *exec.Cmd, sz *Winsize, attrs *syscall.SysProcAttr) (Pty, error) {
-	pty, _, err := open()
+	pty, tty, err := open()
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +62,7 @@ func StartWithAttrs(c *exec.Cmd, sz *Winsize, attrs *syscall.SysProcAttr) (Pty, 
 		cmd:        c,
 		waitCalled: false,
 		conPty:     pty.(*WindowsPty),
+		conTty:     tty.(*WindowsTty),
 	}
 
 	if err := w.Start(); err != nil {


### PR DESCRIPTION
pty_windows.go closed consoleW and consoleR in the initial open(), with the comment "These pipes can be closed here without any worry."

This isn't actually true.

If you interact with the terminal via Go code (i.e. don't immediately fork a new process, but use (for example) github.com/mvdan/sh), you need those pipes to stay open, and to close them yourself.